### PR TITLE
upgrade from v1.13.10 to v1.13.11

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ geth_account_pass_file: '{{ geth_cont_vol }}/keys/account.pass'
 geth_account_addr_file: '{{ geth_cont_vol }}/keys/account.addr'
 
 # Container config
-geth_cont_tag: 'v1.13.10'
+geth_cont_tag: 'v1.13.11'
 geth_cont_image: 'ethereum/client-go:{{ geth_cont_tag }}'
 geth_cont_name: '{{ geth_service_name }}-node'
 geth_cont_vol: '{{ geth_service_path }}/node'


### PR DESCRIPTION
  Upgrade from Cancun migration of Holesky and Sepolia network
  https://github.com/ethereum/go-ethereum/releases/tag/v1.13.11